### PR TITLE
EASY-2278: make user naming conventions consistent with easy-app

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+Fixes EASY-
+
+#### When applied it will
+* 
+* 
+* 
+
+#### Where should the reviewer @DANS-KNAW/easy start?
+
+#### How should this be manually tested?
+
+#### related pull requests on github
+repo                       | PR
+-------------------------- | -----------------
+easy-                      | [PR#](PRlink) 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,1 @@
-easy_test_users_email: "unknown@unknown.org"
+easy_test_users_email: "unknown@dans.knaw.nl"

--- a/tasks/add_user.yml
+++ b/tasks/add_user.yml
@@ -35,4 +35,3 @@
   command: ldapadd -w {{ easy_test_users_ldapadmin_password }} -D cn=ldapadmin,dc=dans,dc=knaw,dc=nl
     -f /home/vagrant/add-user-{{ uid }}.ldif
   when: add_script.stat.exists == False
-    

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,54 +18,78 @@
     ldif_template: add-user.ldif
     uid: user001
     firstname: User001First
+    initials: "U.F."
     surname: User001Last
+    commonname: "User001Last, U.F. (User001First)"
+    displayname: "User001First User001Last"
     sword_allowed: "TRUE"
 - import_tasks: add_user.yml
   vars:
     ldif_template: add-user.ldif
     uid: user002
     firstname: User002First
+    initials: "U.F."
     surname: User002Last
+    commonname: "User002Last, U.F. (User002First)"
+    displayname: "User002First User002Last"
     sword_allowed: "FALSE"
 - import_tasks: add_user.yml
   vars:
     ldif_template: add-archivist-user.ldif
     uid: archie001
     firstname: Archie
+    initials: "A."
     surname: "Man of Steel"
+    commonname: "Man of Steel, A. (Archie)"
+    displayname: "Archie Man of Steel"
     sword_allowed: "FALSE"
 - import_tasks: add_user.yml
   vars:
     ldif_template: add-archaeologist-user.ldif
     uid: digger001
     firstname: Treasure
+    initials: "T."
     surname: Digger
+    commonname: "Digger, T. (Treasure)"
+    displayname: "Treasure Digger"
     sword_allowed: "FALSE"
 - import_tasks: add_user.yml
   vars:
     ldif_template: add-user.ldif
     uid: mendeltest
     firstname: Data
+    initials: "D."
     surname: Mendel
+    commonname: "Mendel, D. (Data)"
+    displayname: "Data Mendel"
     sword_allowed: "TRUE"
 - import_tasks: add_user.yml
   vars:
     ldif_template: add-user.ldif
     uid: IPDBSTest
     firstname: Publisher
+    initials: "P."
     surname: PDBS
+    commonname: "PDBS, P. (Publisher)"
+    displayname: "Publisher PDBS"
     sword_allowed: "TRUE"
 - import_tasks: add_user.yml
   vars:
     ldif_template: add-user.ldif
     uid: tlatest
     firstname: Data
+    initials: "D."
     surname: TLA
+    commonname: "TLA, D. (Data)"
+    displayname: "Data TLA"
     sword_allowed: "TRUE"
 - import_tasks: add_user.yml
   vars:
     ldif_template: add-user.ldif
     uid: pantest
     firstname: Peter
+    initials: "P."
     surname: PAN
+    commonname: "PAN, P. (Peter)"
+    displayname: "Peter PAN"
     sword_allowed: "TRUE"

--- a/templates/add-archaeologist-user.ldif
+++ b/templates/add-archaeologist-user.ldif
@@ -5,19 +5,19 @@ objectClass: organizationalPerson
 objectClass: inetOrgPerson
 objectClass: dansUser
 objectClass: easyUser
-cn: {{ firstname }}
+cn: {{ commonname }}
 sn: {{ surname }}
 uid: {{ uid }}
 dansAcceptConditionsOfUse: TRUE
 dansNewsletter: FALSE
 dansState: ACTIVE
-displayName: {{ firstname }} {{ surname }}
+displayName: {{ displayname }}
 easyHasConfirmedGeneralConditions: FALSE
 easyLogMyActions: TRUE
 easyRoles: USER
 easyGroups: Archeology
-givenName: EASY
-initials: E A
+givenName: {{ firstname }}
+initials: {{ initials }}
 l: Den Haag
 o: DANS
 mail: {{ easy_test_users_email }}

--- a/templates/add-archivist-user.ldif
+++ b/templates/add-archivist-user.ldif
@@ -5,19 +5,19 @@ objectClass: organizationalPerson
 objectClass: inetOrgPerson
 objectClass: dansUser
 objectClass: easyUser
-cn: {{ firstname }}
+cn: {{ commonname }}
 sn: {{ surname }}
 uid: {{ uid }}
 dansAcceptConditionsOfUse: TRUE
 dansNewsletter: FALSE
 dansState: ACTIVE
-displayName: {{ firstname }} {{ surname }}
+displayName: {{ displayname }}
 easyHasConfirmedGeneralConditions: FALSE
 easyLogMyActions: TRUE
 easyRoles: USER
 easyRoles: ARCHIVIST
-givenName: EASY
-initials: E A
+givenName: {{ firstname }}
+initials: {{ initials }}
 l: Den Haag
 o: DANS
 mail: {{ easy_test_users_email }}

--- a/templates/add-user.ldif
+++ b/templates/add-user.ldif
@@ -5,19 +5,19 @@ objectClass: organizationalPerson
 objectClass: inetOrgPerson
 objectClass: dansUser
 objectClass: easyUser
-cn: {{ firstname }}
+cn: {{ commonname }}
 sn: {{ surname }}
 uid: {{ uid }}
 dansAcceptConditionsOfUse: TRUE
 dansNewsletter: FALSE
 dansState: ACTIVE
-displayName: {{ firstname }} {{ surname }}
+displayName: {{ displayname }}
 easyHasConfirmedGeneralConditions: FALSE
 easyLogMyActions: TRUE
 easyRoles: USER
 easySwordDepositAllowed: {{ sword_allowed }}
-givenName: EASY
-initials: E A
+givenName: {{ firstname }}
+initials: {{ initials }}
 l: Den Haag
 o: DANS
 mail: {{ easy_test_users_email }}


### PR DESCRIPTION
Fixes EASY-2278

#### When applied it will
* make user naming conventions consistent with [`easy-app`](https://github.com/DANS-KNAW/easy-app/blob/00ccbaf409a931e7dfeb0bb0ef011e413b1fb8d2/lib-deprecated/dans-lang/src/main/java/nl/knaw/dans/common/lang/user/PersonVO.java)

#### How should this be manually tested?
* in `easy-dtap`:
    * Destroy your `deasy` VM (`vagrant destroy -f`)
    * Link the `dans.easy-test-users`, which is checked out on this PR (`./create-role-link.sh dans.easy-test-users`)
    * Remove `dans.easy-test-users` from `requirements.yml`
    * Turn off the use of the preprovisioned basebox (`./toggle-preprovisioned.sh deasy`)
    * Build a new `deasy` VM from scratch (don't use an existing preprovisioned basebox!) (`vagrant up deasy`)
* Go to https://deasy.dans.knaw.nl/ui/useroverview (need to login as admin)
* The new names as seen in this pull request should be on display

**_before:_**
![image](https://user-images.githubusercontent.com/5938204/63425172-3f2dd580-c410-11e9-9695-5cac2404a185.png)

**_after:_**
![image](https://user-images.githubusercontent.com/5938204/63428850-d26b0900-c418-11e9-9531-f0eaa0b7e8b8.png)

@DANS-KNAW/easy for review